### PR TITLE
Adding support for plist files and dust files

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,6 +41,7 @@ define(function (require, exports, module) {
 
 	// XML
 	addIcon('xml', '\uf05f', '#ff6600');
+	addIcon('plist', '\uf05f', '#5883f9');
 	addIcon('html', '\uf13b', '#d28445');
 	addAlias('htm', 'html');
 

--- a/main.js
+++ b/main.js
@@ -75,7 +75,7 @@ define(function (require, exports, module) {
 
 	// Templating
 	addIcon('jade', '\uf13b', '#01dfa5');
-    addIcon('dust', '\uf13b', '#d28445');
+	addIcon('dust', '\uf13b', '#d28445');
 
 	// Images
 	addIcon('png', '\uf012', '#dbb1a9');

--- a/main.js
+++ b/main.js
@@ -75,6 +75,7 @@ define(function (require, exports, module) {
 
 	// Templating
 	addIcon('jade', '\uf13b', '#01dfa5');
+    addIcon('dust', '\uf13b', '#d28445');
 
 	// Images
 	addIcon('png', '\uf012', '#dbb1a9');

--- a/readme.md
+++ b/readme.md
@@ -28,11 +28,13 @@ The following files are supported at the moment:
  - HTML
  - SVG
  - XML
+ - plist
  - PHP, SQL
  - Java
  - CSS, SASS, Less, Stylus
  - Shell script, Batch
  - Jade
+ - Dust
  - TXT
  - Log
  - Markdown

--- a/readme.md
+++ b/readme.md
@@ -10,14 +10,6 @@ Screenshots
 Supported files
 ---------------
 
-7/27/14 - New files supported!
-
-- HTM
-- EJS
-- COMMAND
-- GitAttributes
-- ORG (editorconfig.org)
-
 The following files are supported at the moment:
 
  - JavaScript
@@ -25,16 +17,15 @@ The following files are supported at the moment:
  - TypeScript
  - CoffeeScript
  - LiveScript
- - HTML
+ - HTML, HTM
  - SVG
  - XML
  - plist
  - PHP, SQL
  - Java
  - CSS, SASS, Less, Stylus
- - Shell script, Batch
- - Jade
- - Dust
+ - Shell script, Batch, command
+ - Jade, EJS, Dust
  - TXT
  - Log
  - Markdown
@@ -43,8 +34,8 @@ The following files are supported at the moment:
  - MP4, WebM, OGG
  - MP3, WAV
  - EOT, TTF, WOFF
- - GitIgnore, GitModules
- - NPMIgnore
+ - GitIgnore, GitModules, GitAttributes
+ - NPMIgnore, ORG (editorconfig.org)
  - HTAccess, HTPasswd, Conf
  - YAML
  - Project, Jscsrc, Jshintrc, Csslintrc, Todo, Classpath


### PR DESCRIPTION
This change adds support for OS X and iOS plist files. The color chosen for the icon is the current default OS X highlight color.